### PR TITLE
se quito la version 3.6 de jquery

### DIFF
--- a/rentdesk/template/index.php
+++ b/rentdesk/template/index.php
@@ -130,8 +130,6 @@ $version_app = $config->version_app;
 
   <!-- bruno -->
   <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
-  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-
 
 
 


### PR DESCRIPTION
se quito esta version para evitar errores con versiones anteriores en componentes funcionales como select entre otros.